### PR TITLE
Update to CUDA 12.8 (with linter fixes)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,12 @@ about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: OTHER
   summary: A meta-package for pinning to a CUDA release version
   description: |
     A meta-package for pinning to a CUDA release version
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://github.com/conda-forge/cuda-version-feedstock
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Sync with conda-forge upstream/main for CUDA 12.8

🔄 **Sync Strategy**: Upstream rebase/merge
📦 **Staging Channel**: sk_test
🔧 **Linter Fixes**: Added license_family and dev_url, removed license_url
⚠️ **Note**: This PR contains upstream changes, staging configuration, and linter fixes.